### PR TITLE
Bsdtar and new containers

### DIFF
--- a/Dockerfile.centos-6
+++ b/Dockerfile.centos-6
@@ -1,3 +1,3 @@
 FROM centos:centos6
 RUN yum update -y && yum -y install wget && wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && rpm -ivh epel-release-6-8.noarch.rpm
-RUN yum update -y && yum -y install xorg-x11-server-Xorg bsdtar3 fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 libXinerama libXrandr libXcursor libXcomposite && cd /usr/bin && ln -s bsdtar3 bsdtar
+RUN yum update -y && yum -y install xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 libXinerama libXrandr libXcursor libXcomposite

--- a/Dockerfile.centos-7
+++ b/Dockerfile.centos-7
@@ -1,3 +1,3 @@
 FROM centos:centos7
 #RUN yum update -y && yum -y install wget && wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && rpm -ivh epel-release-6-8.noarch.rpm
-RUN yum update -y && yum -y install wget xorg-x11-server-Xorg bsdtar3 fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 libXinerama libXrandr libXcursor libXcomposite && cd /usr/bin && ln -s bsdtar3 bsdtar
+RUN yum update -y && yum -y install wget xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 libXinerama libXrandr libXcursor libXcomposite

--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -1,0 +1,2 @@
+FROM centos:centos8
+RUN yum update -y && yum -y install wget xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 libXinerama libXrandr libXcursor libXcomposite

--- a/Dockerfile.debian-stable
+++ b/Dockerfile.debian-stable
@@ -1,2 +1,2 @@
 FROM debian:stable
-RUN apt-get update && apt-get install -y xorg libgomp1 bsdtar less nano binutils libasound2
+RUN apt-get update && apt-get install -y xorg libgomp1 less nano binutils libasound2

--- a/Dockerfile.debian-testing
+++ b/Dockerfile.debian-testing
@@ -1,2 +1,2 @@
 FROM debian:testing
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y xorg libgomp1 bsdtar less nano binutils libasound2
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y xorg libgomp1 less nano binutils libasound2

--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -1,3 +1,3 @@
 FROM fedora:26
-RUN yum update -y && yum -y install xorg-x11-server-Xorg bsdtar fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64
+RUN yum update -y && yum -y install xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64
 RUN dbus-uuidgen > /etc/machine-id

--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -1,3 +1,3 @@
 FROM fedora:27
-RUN yum update -y && yum -y install xorg-x11-server-Xorg bsdtar fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64
+RUN yum update -y && yum -y install xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64
 RUN dbus-uuidgen > /etc/machine-id

--- a/Dockerfile.fedora-31
+++ b/Dockerfile.fedora-31
@@ -1,0 +1,3 @@
+FROM fedora:31
+RUN yum update -y && yum -y install xorg-x11-server-Xorg fontconfig binutils findutils mesa-libEGL.x86_64 libSM.x86_64 dbus-tools mesa-dri-drivers
+RUN dbus-uuidgen > /etc/machine-id

--- a/Dockerfile.ubuntu-14.04
+++ b/Dockerfile.ubuntu-14.04
@@ -1,3 +1,3 @@
 FROM ubuntu:14.04
-RUN apt-get update && apt-get install -y software-properties-common libX11-6 libegl1-mesa libgl1-mesa-glx expat strace bsdtar binutils fontconfig libsm6 dbus
+RUN apt-get update && apt-get install -y software-properties-common libX11-6 libegl1-mesa libgl1-mesa-glx expat strace binutils fontconfig libsm6 dbus
 RUN dbus-uuidgen > /etc/machine-id

--- a/Dockerfile.ubuntu-16.04
+++ b/Dockerfile.ubuntu-16.04
@@ -1,2 +1,2 @@
 FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y software-properties-common libx11-6 libegl1-mesa libgl1-mesa-glx expat strace bsdtar binutils fontconfig libsm6 libgomp1 valgrind gdb nano kcachegrind
+RUN apt-get update && apt-get install -y software-properties-common libx11-6 libegl1-mesa libgl1-mesa-glx expat strace binutils fontconfig libsm6 libgomp1 valgrind gdb nano kcachegrind

--- a/Dockerfile.ubuntu-18.04
+++ b/Dockerfile.ubuntu-18.04
@@ -1,3 +1,3 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y software-properties-common libx11-6 libegl1-mesa libgl1-mesa-glx expat strace bsdtar binutils fontconfig libsm6 libgomp1 valgrind gdb nano kcachegrind dbus curl desktop-file-utils
+RUN apt-get update && apt-get install -y software-properties-common libx11-6 libegl1-mesa libgl1-mesa-glx expat strace binutils fontconfig libsm6 libgomp1 valgrind gdb nano kcachegrind dbus curl desktop-file-utils
 RUN dbus-uuidgen > /etc/machine-id

--- a/Dockerfile.ubuntu-19.04
+++ b/Dockerfile.ubuntu-19.04
@@ -1,0 +1,3 @@
+FROM ubuntu:19.04
+RUN apt-get update && apt-get install -y software-properties-common libx11-6 libegl1-mesa libgl1-mesa-glx expat strace binutils fontconfig libsm6 libgomp1 valgrind gdb nano kcachegrind dbus curl desktop-file-utils
+RUN dbus-uuidgen > /etc/machine-id

--- a/aitest.sh
+++ b/aitest.sh
@@ -2,6 +2,6 @@
 
 rm -rf /AppDir && mkdir /AppDir
 cd /AppDir
-#bsdtar xfp /AppImage
+
 /AppImage --appimage-extract
 /AppDir/squashfs-root/AppRun


### PR DESCRIPTION
While using this tool I extended it a little bit :smiley: 

* Added dockerfiles for centos-8, ubuntu-19.04 and fedora 31
* Removed the bsdtar package as it was not available on all platforms and not needed.